### PR TITLE
add link to Spotify account playlist for song cards

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -8,6 +8,11 @@ import loading from '../../assets/loading.png'
 import'./App.css'
 
 const App = () => {
+  const CLIENT_ID = '006804fd2b7a4eb5aaee1c88d0716840'
+  const REDIRECT_URI = "http://localhost:3000"
+  const AUTH_ENDPOINT = "https://accounts.spotify.com/authorize"
+  const RESPONSE_TYPE = "token"
+
   const [songs, setSongs] = useState([])
   const [errorMessage, setErrorMessage] = useState('')
  
@@ -22,6 +27,7 @@ const App = () => {
     return (
     <div className='app-container'>
       <main>
+        <a href={`${AUTH_ENDPOINT}?client_id-${CLIENT_ID}&redirect_uri-${REDIRECT_URI}&response_type-${RESPONSE_TYPE}`}>login to Spotify</a>
       <Header />
       <Switch>
       <Route exact path='/' render={() => <Songs songs={songs} />} />

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -1,48 +1,70 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import heart from '../../assets/heart-icon.png'
-import active from '../../assets/active-heart-icon.png'
-import './Card.css'
-import { useSelector, useDispatch } from 'react-redux';
-import { saveSong, deleteSong } from '../../features/saveSong/saveSongSlice';
+import React from "react";
+import PropTypes from "prop-types";
+import heart from "../../assets/heart-icon.png";
+import active from "../../assets/active-heart-icon.png";
+import "./Card.css";
+import { useSelector, useDispatch } from "react-redux";
+import { saveSong, deleteSong } from "../../features/saveSong/saveSongSlice";
 
 // React Redux Hooks:
 // useSelector - get info from the store
 // useDispatch - dispatch the action on reducers (saveSong and deleteSong)
 
-const Card = ({ id, albumCover, album, releaseDate, artist, songTitle, genre }) => {
-    const dispatch = useDispatch()
-    const faveSongs = useSelector(state => state.favoriteSongs)
+const Card = ({
+  id,
+  albumCover,
+  album,
+  releaseDate,
+  artist,
+  songTitle,
+  genre,
+}) => {
+  const dispatch = useDispatch();
+  const faveSongs = useSelector((state) => state.favoriteSongs);
 
-    return (
-        <div className='card'>
-            <img className='mini-album-cover' alt='album cover' src={albumCover}/>
-            <div className='heart-container'>
-                {!faveSongs.favoriteSongs.includes(id) && (
-                    <img src={heart} alt="add favorite" onClick={() => dispatch(saveSong(id))} />
-                )}
-                {faveSongs.favoriteSongs.includes(id) && (
-            
-                    <img src={active} alt="delete favorite"  onClick={() => dispatch(deleteSong(id))} />
-                )}
-            </div>
-            <p className='album-card'>Album: {album}</p>
-            <p className='release-date-card'>Release Date: {releaseDate}</p>
-            <p className='artist-card'>Artist: {artist}</p>
-            <p className='song-card'>Song: {songTitle}</p>
-            <p className='genre-card'>Genre: {genre}</p>
-        </div>
-    )
-}
+  return (
+    <div className="card">
+      <img className="mini-album-cover" alt="album cover" src={albumCover} />
+      <div className="heart-container">
+        {!faveSongs.favoriteSongs.includes(id) && (
+          <img
+            src={heart}
+            alt="add favorite"
+            onClick={() => dispatch(saveSong(id))}
+          />
+        )}
+        {faveSongs.favoriteSongs.includes(id) && (
+          <img
+            src={active}
+            alt="delete favorite"
+            onClick={() => dispatch(deleteSong(id))}
+          />
+        )}
+      </div>
+      <p className="album-card">Album: {album}</p>
+      <p className="release-date-card">Release Date: {releaseDate}</p>
+      <p className="artist-card">Artist: {artist}</p>
+      <a
+        className="song-card"
+        href="https://open.spotify.com/playlist/4E4reOpjBY0iwYUCtWeM76"
+        rel="noreferrer"
+        target="_blank"
+      >
+        Song: {songTitle}
+      </a>
+      <p className="genre-card">Genre: {genre}</p>
+    </div>
+  );
+};
 
-export default Card
+export default Card;
 
 Card.propTypes = {
-    id: PropTypes.number.isRequired,
-    albumCover: PropTypes.string.isRequired,
-    album: PropTypes.string.isRequired,
-    releaseDate: PropTypes.string.isRequired,
-    artist: PropTypes.string.isRequired, 
-    songTitle: PropTypes.string.isRequired,
-    genre: PropTypes.string.isRequired,
-}
+  id: PropTypes.number.isRequired,
+  albumCover: PropTypes.string.isRequired,
+  album: PropTypes.string.isRequired,
+  releaseDate: PropTypes.string.isRequired,
+  artist: PropTypes.string.isRequired,
+  songTitle: PropTypes.string.isRequired,
+  genre: PropTypes.string.isRequired,
+};

--- a/src/features/saveSong/saveSongSlice.js
+++ b/src/features/saveSong/saveSongSlice.js
@@ -1,32 +1,33 @@
-import { createSlice } from "@reduxjs/toolkit"
+import { createSlice } from "@reduxjs/toolkit";
 
-// global centralized state via Redux 
-// reducers live in this slice.js file 
+// global centralized state via Redux
+// reducers live in this slice.js file
 
 const initialState = {
-    favoriteSongs: [],
-
-}
+  favoriteSongs: [],
+};
 
 export const saveSongSlice = createSlice({
-    // matches initialState = favoriteSongs
-    // access initialState
-    // reducers - action performed (i.e., increment and decrement actions)
-    name: 'favoriteSongs',
-    initialState,
-    reducers: {
-        saveSong: (state, action) => {
-            // state and action passed in 
-            // either adding a song to the playlist or deleting from the playlist
-            state.favoriteSongs.push(action.payload)
-        },
+  // matches initialState = favoriteSongs
+  // access initialState
+  // reducers - action performed (i.e., increment and decrement actions)
+  name: "favoriteSongs",
+  initialState,
+  reducers: {
+    saveSong: (state, action) => {
+      // state and action passed in
+      // either adding a song to the playlist or deleting from the playlist
+      state.favoriteSongs.push(action.payload);
+    },
 
-        deleteSong: (state, action) => {
-            state.favoriteSongs = state.favoriteSongs.filter(song => song !== action.payload)
-        }
-    }
-})
+    deleteSong: (state, action) => {
+      state.favoriteSongs = state.favoriteSongs.filter(
+        (song) => song !== action.payload
+      );
+    },
+  },
+});
 
-export const { saveSong, deleteSong } = saveSongSlice.actions
+export const { saveSong, deleteSong, openYouTubeSong } = saveSongSlice.actions;
 
-export default saveSongSlice.reducer 
+export default saveSongSlice.reducer;


### PR DESCRIPTION
## Pull Request

### Category:
[Fix]
[Feature]
[Style]
[Test]
[Docs]
[Chore]
[Suggestion]
[Issue]

### Overview:
[Feature]

### Where should the reviewer start?
Card.js file 

## Specific Changes:
* added an anchor tag <a> </a> with href to Spotify playlist in account of songs displayed on each card 
* when a user clicks on the link for song title the user will be redirected to Spotify to be able to play songs from playlist

* ideally, want to link each individual song when a song title is selected from a card and not the entire playlist 