### PR TITLE
modify package.json file for Vercel updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",


### PR DESCRIPTION
## Pull Request

### Category:
[Fix]


### Overview:
- changes made to package.json file to reflect Node.js 16 will no longer be supported on Vercel

### Where should the reviewer start?
- package.json

## Specific Changes:
* adds "engines": {   "node": "22.x" }, 

### Why:
- Vercel required upgrade 