### PR TITLE
add conditional rendering to isFlipped state or card flip

### DIFF
--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -40,74 +40,78 @@ const Card = ({
       data-cy="card-element"
       onClick={handleCardFlip}
     >
-      <div
-        className="card-side card-side-front"
-        data-cy="card-side-front-element"
-      >
-        <LazyLoadImage
-          className="mini-album-cover"
-          data-cy="mini-album-cover-img"
-          alt="album cover"
-          src={albumCover}
-          effect="opacity"
-        />
-        <p className="album-card" data-cy="album-card-element">
-          Album: {album}
-        </p>
-        <p className="release-date-card" data-cy="release-date-card-element">
-          Release Date: {releaseDate}
-        </p>
-        <p className="artist-card" data-cy="artist-card-element">
-          Artist: {artist}
-        </p>
-        <p className="genre-card" data-cy="genre-card-element">
-          Genre: {genre}
-        </p>
-      </div>
-      <div
-        className="card-side card-side-back"
-        data-cy="card-side-back-element"
-      >
-        <div className="heart-container" data-cy="heart-container-element">
-          {!faveSongs.favoriteSongs.includes(id) && (
-            <img
-              className="heart-icon"
-              data-cy="heart-icon-element"
-              src={heart}
-              alt="add favorite"
-              onClick={() => dispatch(saveSong(id))}
-            />
-          )}
-          {faveSongs.favoriteSongs.includes(id) && (
-            <img
-              className="heart-icon"
-              data-cy="heart-icon-element"
-              src={active}
-              alt="delete favorite"
-              onClick={() => dispatch(deleteSong(id))}
-            />
-          )}
-        </div>
-        <LazyLoadImage
-          className="mini-album-cover-back"
-          data-cy="mini-album-cover-back-img"
-          alt="album cover"
-          src={albumCover}
-          effect="opacity"
-        />
-        <p className="song-details-card" data-cy="song-details-card-element">
-          {songDetails}
-        </p>
-        <a
-          className="song-card"
-          data-cy="song-card-song"
-          href="https://open.spotify.com/playlist/4E4reOpjBY0iwYUCtWeM76"
-          rel="noreferrer"
-          target="_blank"
+      {!isFlipped && (
+        <div
+          className="card-side card-side-front"
+          data-cy="card-side-front-element"
         >
-          Song: {songTitle}
-        </a>
-      </div>
+          <LazyLoadImage
+            className="mini-album-cover"
+            data-cy="mini-album-cover-img"
+            alt="album cover"
+            src={albumCover}
+            effect="opacity"
+          />
+          <p className="album-card" data-cy="album-card-element">
+            Album: {album}
+          </p>
+          <p className="release-date-card" data-cy="release-date-card-element">
+            Release Date: {releaseDate}
+          </p>
+          <p className="artist-card" data-cy="artist-card-element">
+            Artist: {artist}
+          </p>
+          <p className="genre-card" data-cy="genre-card-element">
+            Genre: {genre}
+          </p>
+        </div>
+      )}
+      {isFlipped && (
+        <div
+          className="card-side card-side-back"
+          data-cy="card-side-back-element"
+        >
+          <div className="heart-container" data-cy="heart-container-element">
+            {!faveSongs.favoriteSongs.includes(id) && (
+              <img
+                className="heart-icon"
+                data-cy="heart-icon-element"
+                src={heart}
+                alt="add favorite"
+                onClick={() => dispatch(saveSong(id))}
+              />
+            )}
+            {faveSongs.favoriteSongs.includes(id) && (
+              <img
+                className="heart-icon"
+                data-cy="heart-icon-element"
+                src={active}
+                alt="delete favorite"
+                onClick={() => dispatch(deleteSong(id))}
+              />
+            )}
+          </div>
+          <LazyLoadImage
+            className="mini-album-cover-back"
+            data-cy="mini-album-cover-back-img"
+            alt="album cover"
+            src={albumCover}
+            effect="opacity"
+          />
+          <p className="song-details-card" data-cy="song-details-card-element">
+            {songDetails}
+          </p>
+          <a
+            className="song-card"
+            data-cy="song-card-song"
+            href="https://open.spotify.com/playlist/4E4reOpjBY0iwYUCtWeM76"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Song: {songTitle}
+          </a>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Pull Request

### Category:
[Fix]

### Overview:

Fixed card flip animation issue on mobile devices where front-side content would not display after flipping back from the back side. Users had to click outside the card or on a different card to trigger a re-render and see the front content again.

### Where should the reviewer start?

- src/components/Card/Card.js


## Specific Changes:

- Added conditional rendering. Card sides now render conditionally based on isFlipped state, instead of both back-side and front-side of card existing simultaneously in the DOM. 
- Desktop users can still hover to flip cards; mobile users tap to toggle.
