### PR TITLE
Fix/showcase project card flip click

### DIFF
--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -14,7 +14,6 @@
   transition: transform 0.8s ease;
   touch-action: manipulation;
   -webkit-tap-highlight-color: transparent;
-  cursor: pointer;
 }
 
 .card.flipped {

--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -29,10 +29,8 @@
   transform: rotateY(180deg);
 }
 
-@media (hover: hover) and (pointer: fine) {
-  .card:hover {
-    transform: rotateY(180deg);
-  }
+.card-side.hidden {
+  display: none !important;
 }
 
 .card-side {
@@ -58,15 +56,6 @@
 
 .card-side-back {
   background-image: linear-gradient(#dc3deb, #9e2fd6, #7114f5);
-  transform: rotateY(180deg);
-}
-
-.card:hover .card-side-front {
-  transform: rotateY(180deg);
-  opacity: 0;
-}
-
-.card:hover .card-side-back {
   transform: rotateY(180deg);
 }
 

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -41,82 +41,79 @@ const Card = ({
 
   return (
     <div
-      className={`card generic-card ${className} ${isFlipped ? "flipped" : ""}`}
+      className={`card ${className} ${isFlipped ? "flipped" : ""}`}
       data-cy="card-element"
       onClick={handleCardFlip}
     >
-      {!isFlipped && (
-        <div
-          className="card-side card-side-front"
-          data-cy="card-side-front-element"
-        >
-          <LazyLoadImage
-            className="mini-album-cover"
-            data-cy="mini-album-cover-img"
-            alt="album cover"
-            src={albumCover}
-            effect="opacity"
-          />
-          <p className="album-card" data-cy="album-card-element">
-            Album: {album}
-          </p>
-          <p className="release-date-card" data-cy="release-date-card-element">
-            Release Date: {releaseDate}
-          </p>
-          <p className="artist-card" data-cy="artist-card-element">
-            Artist: {artist}
-          </p>
-          <p className="genre-card" data-cy="genre-card-element">
-            Genre: {genre}
-          </p>
+      <div
+        className={`card-side card-side-front ${isFlipped ? "hidden" : ""}`}
+        data-cy="card-side-front-element"
+      >
+        <LazyLoadImage
+          className="mini-album-cover"
+          data-cy="mini-album-cover-img"
+          alt="album cover"
+          src={albumCover}
+          effect="opacity"
+        />
+        <p className="album-card" data-cy="album-card-element">
+          Album: {album}
+        </p>
+        <p className="release-date-card" data-cy="release-date-card-element">
+          Release Date: {releaseDate}
+        </p>
+        <p className="artist-card" data-cy="artist-card-element">
+          Artist: {artist}
+        </p>
+        <p className="genre-card" data-cy="genre-card-element">
+          Genre: {genre}
+        </p>
+      </div>
+
+      <div
+        className={`card-side card-side-back ${!isFlipped ? "hidden" : ""}`}
+        data-cy="card-side-back-element"
+      >
+        <div className="heart-container" data-cy="heart-container-element">
+          {!faveSongs.favoriteSongs.includes(id) && (
+            <img
+              className="heart-icon"
+              data-cy="heart-icon-element"
+              src={heart}
+              alt="add favorite"
+              onClick={() => dispatch(saveSong(id))}
+            />
+          )}
+          {faveSongs.favoriteSongs.includes(id) && (
+            <img
+              className="heart-icon"
+              data-cy="heart-icon-element"
+              src={active}
+              alt="delete favorite"
+              onClick={() => dispatch(deleteSong(id))}
+            />
+          )}
         </div>
-      )}
-      {isFlipped && (
-        <div
-          className="card-side card-side-back"
-          data-cy="card-side-back-element"
+        <LazyLoadImage
+          className="mini-album-cover-back"
+          data-cy="mini-album-cover-back-img"
+          alt="album cover"
+          src={albumCover}
+          effect="opacity"
+        />
+        <p className="song-details-card" data-cy="song-details-card-element">
+          {songDetails}
+        </p>
+        <a
+          className="song-card"
+          data-cy="song-card-song"
+          href="https://open.spotify.com/playlist/4E4reOpjBY0iwYUCtWeM76"
+          rel="noreferrer"
+          target="_blank"
         >
-          <div className="heart-container" data-cy="heart-container-element">
-            {!faveSongs.favoriteSongs.includes(id) && (
-              <img
-                className="heart-icon"
-                data-cy="heart-icon-element"
-                src={heart}
-                alt="add favorite"
-                onClick={() => dispatch(saveSong(id))}
-              />
-            )}
-            {faveSongs.favoriteSongs.includes(id) && (
-              <img
-                className="heart-icon"
-                data-cy="heart-icon-element"
-                src={active}
-                alt="delete favorite"
-                onClick={() => dispatch(deleteSong(id))}
-              />
-            )}
-          </div>
-          <LazyLoadImage
-            className="mini-album-cover-back"
-            data-cy="mini-album-cover-back-img"
-            alt="album cover"
-            src={albumCover}
-            effect="opacity"
-          />
-          <p className="song-details-card" data-cy="song-details-card-element">
-            {songDetails}
-          </p>
-          <a
-            className="song-card"
-            data-cy="song-card-song"
-            href="https://open.spotify.com/playlist/4E4reOpjBY0iwYUCtWeM76"
-            rel="noreferrer"
-            target="_blank"
-          >
-            Song: {songTitle}
-          </a>
-        </div>
-      )}
+          Song: {songTitle}
+        </a>
+      </div>
     </div>
   );
 };
@@ -132,4 +129,5 @@ Card.propTypes = {
   songTitle: PropTypes.string.isRequired,
   genre: PropTypes.string.isRequired,
   className: PropTypes.string,
+  isFlipped: PropTypes.bool,
 };

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -18,12 +18,17 @@ const Card = ({
   genre,
   songDetails,
   className,
+  isFlipped: initialIsFlipped = false,
 }) => {
   const dispatch = useDispatch();
   const faveSongs = useSelector((state) => state.favoriteSongs);
-  const [isFlipped, setIsFlipped] = useState(false);
+  const [isFlipped, setIsFlipped] = useState(initialIsFlipped);
 
   const handleCardFlip = (event) => {
+    if (className === "playlist-card") {
+      return;
+    }
+
     if (
       event.target.closest(".heart-container") ||
       event.target.closest(".song-card")

--- a/src/components/Playlist/Playlist.css
+++ b/src/components/Playlist/Playlist.css
@@ -1,34 +1,3 @@
-.songs-container .card.playlist-card .card-side,
-.songs-container .card.playlist-card .card-side-front,
-.songs-container .card.playlist-card .card-side-back {
-  transform: none;
-  opacity: 1;
-  transition: none;
-}
-
-.songs-container .card.playlist-card .card-side-back {
-  background-image: linear-gradient(#dc3deb, #9e2fd6, #7114f5);
-  transform: none;
-}
-
-.songs-container .card.playlist-card:hover .card-side-front {
-  transform: none;
-  opacity: 1;
-}
-
-.songs-container .card.playlist-card:hover .card-side-back {
-  transform: none;
-}
-
-.songs-container .card.playlist-card .mini-album-cover-back {
-  opacity: 1;
-  transition: opacity 1s ease-in-out;
-}
-
-.songs-container .card.playlist-card .mini-album-cover-back:hover {
-  opacity: 0.5;
-}
-
 @media only screen and (min-width: 37.5em) and (max-width: 56.25em) {
   .favorite-songs-message {
     text-transform: uppercase;

--- a/src/components/Playlist/Playlist.js
+++ b/src/components/Playlist/Playlist.js
@@ -21,10 +21,8 @@ const Playlist = ({ songs }) => {
             genre={song.genre}
             songDetails={song.songDetails}
             key={song.id}
-            className={
-              favSongs.favoriteSongs.includes(song.id) ? "playlist-card" : ""
-            }
-          />
+            isFlipped={true}
+          />,
         );
       }
     });


### PR DESCRIPTION
## Pull Request

### Category:
[Fix]

### Overview:

Refactored card flip animation to use consistent click/tap behavior across all devices instead of hover for desktop only. Fixed mobile rendering bug where front-side content would not display after flipping back from the back side.

### Where should the reviewer start?

- src/components/Card/Card.css
- src/components/Card/Card.js
- src/components/Playlist/Playlist.css
- src/components/Playlist/Playlist.js


## Specific Changes:

Card.css:
- .flipped class handles flip animation 
- .hidden class forces display:none for proper rendering 
- No hover behavior (removed for consistency across all devices) 

Card.js:
- Accepts isFlipped prop to control initial state 
- Prevents playlist cards from flipping (className check)
- Uses .hidden class to force re-render and to fix mobile bug 
- Click/tap works on all devices (no hover) 

Playlist.css:
- Removes rules since not passing className="playlist-card" anymore 

Playlist.js: 
- Passes isFlipped={true} to show back-side of card by default 
- No className prop needed (removed playlist-card) 